### PR TITLE
Fix a couple of failing tests

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -88,7 +88,7 @@ class UniswapV2ClientTest(BaseTest):
         self.assertEqual(pair, self.token_pair)
 
     def test_get_pair_by_index_not_found(self):
-        pair = self.uniswap.get_pair_by_index(9999)
+        pair = self.uniswap.get_pair_by_index(99999)
         self.assertEqual(pair, "0x0000000000000000000000000000000000000000")
 
     def test_get_fee(self):

--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -104,9 +104,9 @@ class UniswapObject(object):
         self.private_key = private_key
 
         self.provider = os.environ["PROVIDER"] if not provider else provider
-        if re.match(r'^https*:', self.provider):
+        if re.match(r'^https?:', self.provider):
             provider = Web3.HTTPProvider(self.provider, request_kwargs={"timeout": 60})
-        elif re.match(r'^ws*:', self.provider):
+        elif re.match(r'^wss?:', self.provider):
             provider = Web3.WebsocketProvider(self.provider)
         elif re.match(r'^/', self.provider):
             provider = Web3.IPCProvider(self.provider)

--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -115,7 +115,7 @@ class UniswapObject(object):
         self.conn = Web3(provider)
         if not self.conn.isConnected():
             raise RuntimeError("Unable to connect to provider at " + self.provider)
-        self.gasPrice = self.conn.toWei(15, "gwei"),
+        self.gasPrice = self.conn.toWei(15, "gwei")
 
     def _create_transaction_params(self, value=0, gas=1500000):
         return {

--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -302,7 +302,7 @@ class UniswapV2Client(UniswapObject):
         """
         self.approve(token, amount_token)
         func = self.router.functions.addLiquidityETH(token, amount_token, min_token, min_eth, to, deadline)
-        params = self._create_transaction_params(amount_eth)  # FIXME
+        params = self._create_transaction_params(amount_eth, gas=3000000)  # FIXME
         return self._send_transaction(func, params)
 
     def remove_liquidity(self, token_a, token_b, liquidity, min_a, min_b, to, deadline):


### PR DESCRIPTION
This fixes the test cases, that failed with `TypeError: Transaction had invalid fields: {'gasPrice': (15000000000,)}`

The second commit raises the number that is used to provoke an error by not finding a corresponding pair. The currently used 9999 is already quite close to the current number of pairs being somewhere above 7000.

The last failing test seems to be caused by web3 not properly handling their underlying error.